### PR TITLE
ta - fixed a typo on the documentation/elements/icons.html page

### DIFF
--- a/documentation/elements/icons.html
+++ b/documentation/elements/icons.html
@@ -16,7 +16,7 @@ doc-subtab: icons
     <hr>
 
     <div class="content">
-      <p>Because the icons can talk a few seconds, and because you want control over the <strong>space</strong> the icons will take, you can use the <code>icon</code> class:</p>
+      <p>Because the icons can take a few seconds to load, and because you want control over the <strong>space</strong> the icons will take, you can use the <code>icon</code> class:</p>
     </div>
 
     <div class="example">


### PR DESCRIPTION
Just a small verbiage fix suggestion, to clarify meaning on this page.
