### PR TITLE
added html highlight code for "select dropdown"

### DIFF
--- a/documentation/elements/controls.html
+++ b/documentation/elements/controls.html
@@ -71,6 +71,14 @@ doc-subtab: controls
   <input class="input" type="text" placeholder="Text input">
 </p>
 <p class="control">
+  <span class="select">
+    <select>
+      <option>Select dropdown</option>
+      <option>With options</option>
+    </select>
+  </span>
+</p>
+<p class="control">
   <textarea class="textarea" placeholder="Textarea"></textarea>
 </p>
 <p class="control">


### PR DESCRIPTION
In the html highlight code an example for the select dropdown was missing. This pull request corrects this problem. Cheers!
