### PR TITLE
Added missing is-quarter column in the multiline example

### DIFF
--- a/documentation/grid.html
+++ b/documentation/grid.html
@@ -519,6 +519,9 @@ doc-tab: grid
   <div class="column is-quarter">
     <p class="notification is-warning"><code>is-quarter</code></p>
   </div>
+  <div class="column is-quarter">
+    <p class="notification is-danger"><code>is-quarter</code></p>
+  </div>
   <div class="column">
     <p class="notification is-info">Auto</p>
   </div>


### PR DESCRIPTION
In the grid/is-multiline example, there is a missing .column
