### PR TITLE
add select example code

### DIFF
--- a/documentation/elements/controls.html
+++ b/documentation/elements/controls.html
@@ -71,6 +71,14 @@ doc-subtab: controls
   <input class="input" type="text" placeholder="Text input">
 </p>
 <p class="control">
+  <span class="select">
+    <select>
+      <option>Select dropdown</option>
+      <option>With options</option>
+    </select>
+  </span>
+</p>
+<p class="control">
   <textarea class="textarea" placeholder="Textarea"></textarea>
 </p>
 <p class="control">


### PR DESCRIPTION
the demo has a `<select>` box in it but the code alongside it doesn't have it
