### PR TITLE
MINOR: Open GitHub link externally

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -26,7 +26,7 @@
       </span>
       {% if page.route == 'index' %}
         <span class="header-item">
-          <a id="github" class="button is-dark is-outlined" href="{{ site.github }}">
+          <a id="github" class="button is-dark is-outlined" href="{{ site.github }}" target="_blank">
             <i class="fa fa-github"></i>
             GitHub
           </a>
@@ -43,7 +43,7 @@
         </span>
       {% else %}
         <span class="header-item">
-          <a class="button is-info is-outlined is-inverted" href="{{ site.github }}">
+          <a class="button is-info is-outlined is-inverted" href="{{ site.github }}" target="_blank">
             <i class="fa fa-github"></i>
             GitHub
           </a>


### PR DESCRIPTION
The first thing many developers will do is click the button to be taken to the GitHub repository. This should open externally to also keep the user on the documentation site. 

Side note: sorry this is very pedantic :)
