### PR TITLE
Use correct text-centering class

### DIFF
--- a/documentation/layout/footer.html
+++ b/documentation/layout/footer.html
@@ -16,7 +16,7 @@ doc-subtab: footer
 {% highlight html %}
 <footer class="footer">
   <div class="container">
-    <div class="content is-centered">
+    <div class="content has-text-centered">
       <p>
         <strong>Bulma</strong> by <a href="http://jgthms.com">Jeremy Thomas</a>. The source code is licensed
         <a href="http://opensource.org/licenses/mit-license.php">MIT</a>. The website content


### PR DESCRIPTION
`is-centered` must have been changed to `has-text-centered` because I tried the example and it was not centered. I had to inspect the actual website's footer to find the correct class.
#24 doesn't seem to be the correct fix. Should I close this and suggest the change there since it was opened first.
