### PR TITLE
Update CDN URL

### DIFF
--- a/documentation/overview/start.html
+++ b/documentation/overview/start.html
@@ -31,7 +31,7 @@ npm install bulma
         <p class="title is-5">
           Use the <a href="https://cdnjs.com/" target="_blank">cdnjs</a> <strong>CDN</strong>
           <br>
-          <a href="https://cdnjs.cloudflare.com/ajax/libs/bulma">https://cdnjs.cloudflare.com/ajax/libs/bulma</a>
+          <a href="https://cdnjs.cloudflare.com/ajax/libs/bulma">https://cdnjs.com/libraries/bulma</a>
         </p>
       </div>
     </article>


### PR DESCRIPTION
https://cdnjs.cloudflare.com/ajax/libs/bulma is throwing a 403

In the [readme.md](https://github.com/jgthms/bulma/blob/master/README.md) of the [official repo](https://github.com/jgthms/bulma) the CDN URL is: https://cdnjs.com/libraries/bulma
