### PR TITLE
Fix modal example (remove "modal-container" class)

### DIFF
--- a/documentation/components/modal.html
+++ b/documentation/components/modal.html
@@ -39,10 +39,8 @@ doc-subtab: modal
 {% highlight html %}
 <div class="modal">
   <div class="modal-background"></div>
-  <div class="modal-container">
-    <div class="modal-content">
-      <!-- Any other Bulma elements you want -->
-    </div>
+  <div class="modal-content">
+    <!-- Any other Bulma elements you want -->
   </div>
   <button class="modal-close"></button>
 </div>


### PR DESCRIPTION
The `modal-container` generates an error and does not exist in bulma. See screenshot:

![bildschirmfoto 2016-05-28 um 18 44 34](https://cloud.githubusercontent.com/assets/457834/15628567/4c7aa06e-2504-11e6-89ff-bdd00888da4c.png)

vs.

![bildschirmfoto 2016-05-28 um 18 44 54](https://cloud.githubusercontent.com/assets/457834/15628569/4eb35330-2504-11e6-99c4-aea63098a09a.png)
