### PR TITLE
Spelling mistake on responsiveness.html

### DIFF
--- a/documentation/overview/responsiveness.html
+++ b/documentation/overview/responsiveness.html
@@ -155,7 +155,7 @@ doc-subtab: responsiveness
         <li>the <code>level</code> component will show its children stacked vertically</li>
         <li>the <code>nav</code> menu will be hidden</li>
       </ul>
-      <p>For exapmle, you can enforce the <strong>horizontal</strong> layout for both <code>columns</code> or <code>nav</code> by appending the <code>is-mobile</code> modifer.</p>
+      <p>For example, you can enforce the <strong>horizontal</strong> layout for both <code>columns</code> or <code>nav</code> by appending the <code>is-mobile</code> modifer.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fixed misspelling of 'example' on the bottom of the responsiveness page.
http://bulma.io/documentation/overview/responsiveness/
