### PR TITLE
fix panel-checkbox (same examplecode as sourcecode)

### DIFF
--- a/documentation/components/panel.html
+++ b/documentation/components/panel.html
@@ -99,7 +99,7 @@ doc-subtab: panel
     </span>
     grumpy-cat
   </a>
-  <label class="panel-checkbox">
+  <label class="panel-block">
     <input type="checkbox">
     Remember me
   </label>


### PR DESCRIPTION
changed the panel-checkbox to the everywhere else used panel-block, as it was used in the sourcecode (L36).

Fix for #51.
